### PR TITLE
Make assert equals strict with assertSame

### DIFF
--- a/tests/unit/IntegerTest.php
+++ b/tests/unit/IntegerTest.php
@@ -140,8 +140,8 @@ class IntegerTest extends Unit
                 $rule->validate($value);
                 $this->fail();
             } catch (ValidationError $e) {
-                $this->assertEquals($value, $e->getValue());
-                $this->assertEquals($errors, $e->getSummary());
+                $this->assertSame($value, $e->getValue());
+                $this->assertSame($errors, $e->getSummary());
             }
         }
         $this->assertTrue(true);

--- a/tests/unit/OrRuleTest.php
+++ b/tests/unit/OrRuleTest.php
@@ -73,8 +73,8 @@ class OrRuleTest extends Unit
                 $rule->validate($value);
                 $this->fail();
             } catch (ValidationError $e) {
-                $this->assertEquals($value, $e->getValue());
-                $this->assertEquals($errors, $e->getSummary());
+                $this->assertSame($value, $e->getValue());
+                $this->assertSame($errors, $e->getSummary());
             }
         }
         $this->assertTrue(true);


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals strict.